### PR TITLE
Neo4j persistence fix

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -60,7 +60,7 @@ services:
   neo4j:
     image: bitnami/neo4j
     volumes:
-      - neo4j_data:/data
+      - neo4j_data:/bitnami
     ports:
       - "7474:7474"
       - "7687:7687"


### PR DESCRIPTION
From https://hub.docker.com/r/bitnami/neo4j:
`For persistence you should mount a volume at the /bitnami path`